### PR TITLE
NullReferenceException when finding nodes if not connected

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
     // These variables shouldn't be changed, but sometimes it might be necessary
     solutionName: '<%= projectName %>.sln',
     srcPath: './',
-    dotNetVersion: '4.5.0',
+    dotNetVersion: '4.0.0',
     platform: 'Any CPU',
     styleCopRules: 'Settings.StyleCop',
     ruleSet: 'rules.ruleset',

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
     // These variables shouldn't be changed, but sometimes it might be necessary
     solutionName: '<%= projectName %>.sln',
     srcPath: './',
-    dotNetVersion: '4.0.0',
+    dotNetVersion: '4.5.0',
     platform: 'Any CPU',
     styleCopRules: 'Settings.StyleCop',
     ruleSet: 'rules.ruleset',

--- a/h-opc/Da/DaClient.cs
+++ b/h-opc/Da/DaClient.cs
@@ -142,7 +142,15 @@ namespace Hylasoft.Opc.Da
 
       // try to find the tag otherwise
       var item = new OpcDa.Item { ItemName = tag };
-      var result = _server.Read(new[] { item })[0];
+      OpcDa.ItemValueResult result;
+      try
+      {
+        result = _server.Read(new[] { item })[0];
+      }
+      catch (NullReferenceException)
+      {
+        throw new OpcException("Could not find node because server not connected.");
+      }
       CheckResult(result, tag);
       var node = new DaNode(item.ItemName, item.ItemName, RootNode);
       AddNodeToCache(node);

--- a/h-opc/Da/DaClient.cs
+++ b/h-opc/Da/DaClient.cs
@@ -123,7 +123,20 @@ namespace Hylasoft.Opc.Da
         _server.CancelSubscription(sub)).Start();
 
       sub.DataChanged += (handle, requestHandle, values) =>
-        callback((T)values[0].Value, unsubscribe);
+      {
+        object isCastable;
+        // Make sure data can be cast
+        try
+        {
+          isCastable = (T)System.Convert.ChangeType(values[0].Value, typeof(T));
+        }
+        catch (InvalidCastException)
+        {
+          throw new InvalidCastException(string.Format("Could not monitor tag. Cast failed for type \"{0}\" on the new value \"{1}\" with type \"{2}\". Make sure tag data type matches.", typeof(T), values[0].Value, values[0].Value.GetType()));
+        }
+        if (isCastable == null) return;
+        callback((T)System.Convert.ChangeType(values[0].Value, typeof(T)), unsubscribe);
+      };
       sub.AddItems(new[] { new OpcDa.Item { ItemName = tag } });
       sub.SetEnabled(true);
     }


### PR DESCRIPTION
+ If the client is not connected and you call findnodes you get a null reference exception. I made it more descriptive 
+ This might not be wanted, but I changed the .NET framework build version to 4.0 in the grunt file because I need to use the tool with .NET 4.0. I've yet to test it because I'm not sure what OPC server (is it a demo?) is used in the test scripts
