### PR TITLE
Expose OpcDa server for extensibility purposes

### DIFF
--- a/h-opc/Da/DaClient.cs
+++ b/h-opc/Da/DaClient.cs
@@ -39,7 +39,11 @@ namespace Hylasoft.Opc.Da
     /// <summary>
     /// OpcDa underlying server object.
     /// </summary>
-    protected OpcDa.Server Server => _server;
+    protected OpcDa.Server Server {
+      get {
+        return _server;
+      }
+    }
 
     #region interface methods
 

--- a/h-opc/Da/DaClient.cs
+++ b/h-opc/Da/DaClient.cs
@@ -36,6 +36,11 @@ namespace Hylasoft.Opc.Da
       };
     }
 
+    /// <summary>
+    /// OpcDa underlying server object.
+    /// </summary>
+    protected OpcDa.Server Server => _server;
+
     #region interface methods
 
     /// <summary>


### PR DESCRIPTION
OpcDa server should be exposed as a protected property at least, so that
the end-user of the library could inherit and extend DaClient class for
one's needs.

For example, I need to get timestamp along with each value I read. But I
cannot do so without rewriting Read() method or adding whole new method in
DaClient as well as in IClient<Node> interface.

With this solution, one can easily inherit from DaNode class and implement
any kind of behaviour based on OPC Foundation OpcDa library's
functionality.