### PR TITLE
Bump version number for nuget package update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "h-opc",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-concurrent": "^1.0.0",


### PR DESCRIPTION
Following semantic versioning, second version number should change when
introducing a feature. Extensibility feature was introduced, but version
number was not updated (unfortunately). This fix bumps version number
to v0.6.0 in order to update nuget package.