### PR TITLE
Get data type

### DIFF
--- a/h-opc-cli/Repl.cs
+++ b/h-opc-cli/Repl.cs
@@ -96,7 +96,42 @@ namespace Hylasoft.Opc.Cli
     {
       if (args.Count < 2)
         throw new BadCommandException();
-      _client.Write<object>(GenerateRelativeTag(args[0]), args[1]);
+      var tag = args[0];
+      var val = args[1];
+      var type = _client.GetDataType(GenerateRelativeTag(tag));
+      switch(type.Name) {
+        case "Int32":
+          var val32 = Convert.ToInt32(val);
+          _client.Write<int>(GenerateRelativeTag(tag), val32);
+          break;
+        case "Int16":
+          var val16 = Convert.ToInt16(val);
+          _client.Write<Int16>(GenerateRelativeTag(tag), val16);
+          break;
+        case "UInt16":
+          var valuint16 = Convert.ToUInt16(val);
+          _client.Write<UInt16>(GenerateRelativeTag(tag), valuint16);
+          break;
+        case "UInt32":
+          var valuint32 = Convert.ToUInt32(val);
+          _client.Write<UInt32>(GenerateRelativeTag(tag), valuint32);
+          break;
+        case "Boolean":
+          var valBool = Convert.ToBoolean(val);
+          _client.Write<Boolean>(GenerateRelativeTag(tag), valBool);
+          break;
+        case "Int64":
+          var val64 = Convert.ToInt64(val);
+          _client.Write<Int64>(GenerateRelativeTag(tag), val64);
+          break;
+        case "UInt64":
+          var valuint64 = Convert.ToUInt64(val);
+          _client.Write<UInt64>(GenerateRelativeTag(tag), valuint64);
+          break;
+        default:
+          _client.Write<object>(GenerateRelativeTag(tag), val);
+          break;
+      }
     }
 
     private void Monitor(IList<string> args)

--- a/h-opc/Common/IClient.cs
+++ b/h-opc/Common/IClient.cs
@@ -21,6 +21,13 @@ namespace Hylasoft.Opc.Common
     OpcStatus Status { get; }
 
     /// <summary>
+    /// Gets the datatype of an OPC tag
+    /// </summary>
+    /// <param name="tag">Tag to get datatype of</param>
+    /// <returns>System.Type</returns>
+    System.Type GetDataType(string tag);
+
+    /// <summary>
     /// Read a tag
     /// </summary>
     /// <typeparam name="T">The type of tag to read</typeparam>

--- a/h-opc/Da/DaClient.cs
+++ b/h-opc/Da/DaClient.cs
@@ -37,6 +37,27 @@ namespace Hylasoft.Opc.Da
     }
 
     /// <summary>
+    /// Gets the datatype of an OPC tag
+    /// </summary>
+    /// <param name="tag">Tag to get datatype of</param>
+    /// <returns>System.Type</returns>
+    public System.Type GetDataType(string tag)
+    {
+      var item = new OpcDa.Item { ItemName = tag };
+      OpcDa.ItemProperty result;
+      try
+      {
+        var propertyCollection = _server.GetProperties(new [] {item}, new [] {new OpcDa.PropertyID(1)}, false)[0];
+        result = propertyCollection[0];
+      }
+      catch (NullReferenceException)
+      {
+        throw new OpcException("Could not find node because server not connected.");
+      }
+      return result.DataType;
+    }
+
+    /// <summary>
     /// OpcDa underlying server object.
     /// </summary>
     protected OpcDa.Server Server

--- a/h-opc/Ua/UaClient.cs
+++ b/h-opc/Ua/UaClient.cs
@@ -74,6 +74,27 @@ namespace Hylasoft.Opc.Ua
       PostInitializeSession();
     }
 
+    /// <summary>
+    /// Gets the datatype of an OPC tag
+    /// </summary>
+    /// <param name="tag">Tag to get datatype of</param>
+    /// <returns>System.Type</returns>
+    public System.Type GetDataType(string tag)
+    {
+      var nodesToRead = BuildReadValueIdCollection(tag, Attributes.Value);
+      DataValueCollection results;
+      DiagnosticInfoCollection diag;
+      _session.Read(
+          requestHeader: null,
+          maxAge: 0,
+          timestampsToReturn: TimestampsToReturn.Neither,
+          nodesToRead: nodesToRead,
+          results: out results,
+          diagnosticInfos: out diag);
+      var type = results[0].WrappedValue.TypeInfo.BuiltInType;
+      return System.Type.GetType("System." + Enum.GetName(typeof(TypeCode), type.GetTypeCode()));
+    }
+
     private void SessionKeepAlive(Session session, KeepAliveEventArgs e)
     {
       if (e.CurrentState != ServerState.Running)

--- a/h-opc/Ua/UaClient.cs
+++ b/h-opc/Ua/UaClient.cs
@@ -92,7 +92,7 @@ namespace Hylasoft.Opc.Ua
           results: out results,
           diagnosticInfos: out diag);
       var type = results[0].WrappedValue.TypeInfo.BuiltInType;
-      return System.Type.GetType("System." + Enum.GetName(typeof(TypeCode), type.GetTypeCode()));
+      return System.Type.GetType("System." + type.ToString());
     }
 
     private void SessionKeepAlive(Session session, KeepAliveEventArgs e)

--- a/tests/DaTest.cs
+++ b/tests/DaTest.cs
@@ -112,5 +112,11 @@ namespace Hylasoft.Opc.Tests
       var rootTags = _client.ExploreFolder(string.Empty);
       Assert.Greater(rootTags.Count(), 0);
     }
+    [Test]
+    public void DaGetDataType()
+    {
+      var type = _client.GetDataType(TestRegister);
+      Assert.AreEqual(typeof(Int16), type);
+    }
   }
 }

--- a/tests/UaTest.cs
+++ b/tests/UaTest.cs
@@ -279,8 +279,10 @@ namespace Hylasoft.Opc.Tests
     [Test]
     public void UaGetDataType()
     {
-      var type = _client.GetDataType("Data.Dynamic.Scalar.SByteValue");
-      Assert.AreEqual(typeof(int), type);
+      var type = _client.GetDataType("Data.Dynamic.Scalar.Int32Value");
+      Assert.AreEqual(typeof(Int32), type);
+      type = _client.GetDataType("Data.Dynamic.Scalar.Int16Value");
+      Assert.AreEqual(typeof(Int16), type);
     }
   }
 }

--- a/tests/UaTest.cs
+++ b/tests/UaTest.cs
@@ -276,5 +276,11 @@ namespace Hylasoft.Opc.Tests
       Thread.Sleep(500);
       _client.Dispose();
     }
+    [Test]
+    public void UaGetDataType()
+    {
+      var type = _client.GetDataType("Data.Dynamic.Scalar.SByteValue");
+      Assert.AreEqual(typeof(int), type);
+    }
   }
 }


### PR DESCRIPTION
Added function to both clients for getting the C# data type of a tag by its tag name. This allowed me to fix an issue with getting "BadTypeMismatch" in the CLI for UA client.