### PR TITLE
Allow UA login via username and password in URI

### DIFF
--- a/h-opc/Ua/UaClient.cs
+++ b/h-opc/Ua/UaClient.cs
@@ -460,6 +460,22 @@ namespace Hylasoft.Opc.Ua
     }
 
     /// <summary>
+    /// Return identity login object for a given URI.
+    /// </summary>
+    /// <param name="url">Login URI</param>
+    /// <returns>AnonUser or User with name and password</returns>
+    private UserIdentity GetIdentity(Uri url)
+    {
+       var uriLogin = new UserIdentity();
+       if (!String.IsNullOrEmpty(url.UserInfo))
+       {
+           var uis = url.UserInfo.Split(':');
+           uriLogin = new UserIdentity(uis[0], uis[1]);
+       }
+       return uriLogin;
+    }
+
+    /// <summary>
     /// Crappy method to initialize the session. I don't know what many of these things do, sincerely.
     /// </summary>
     private Session InitializeSession(Uri url)
@@ -534,7 +550,7 @@ namespace Hylasoft.Opc.Ua
           checkDomain: false,
           sessionName: _options.SessionName,
           sessionTimeout: _options.SessionTimeout,
-          identity: null,
+          identity: GetIdentity(url),
           preferredLocales: new string[] { });
 
       return session;

--- a/h-opc/Ua/UaClient.cs
+++ b/h-opc/Ua/UaClient.cs
@@ -467,7 +467,7 @@ namespace Hylasoft.Opc.Ua
     private UserIdentity GetIdentity(Uri url)
     {
        var uriLogin = new UserIdentity();
-       if (!String.IsNullOrEmpty(url.UserInfo))
+       if (!string.IsNullOrEmpty(url.UserInfo))
        {
            var uis = url.UserInfo.Split(':');
            uriLogin = new UserIdentity(uis[0], uis[1]);


### PR DESCRIPTION
UserInfo field of URI object is split on the colon.
Colons in the user name or password aren't supported.
A non empty password is required.

No change if there is no @ in the URI to denote presence of UserInfo.