### PR TITLE
Fixed bug when the tag path exists same name folder will cause an "tag doesn't exist on folder" exception.

### DIFF
--- a/h-opc/Ua/UaClient.cs
+++ b/h-opc/Ua/UaClient.cs
@@ -577,9 +577,13 @@ namespace Hylasoft.Opc.Ua
         throw new OpcException(string.Format("The tag \"{0}\" doesn't exist on folder \"{1}\"", head, node.Tag), ex);
       }
 
-      return folders.Length == 1
+      // remove an array element by converting it to a list
+      var folderList = folders.ToList();
+      folderList.RemoveAt(0); // remove the first node
+      folders = folderList.ToArray();
+      return folders.Length == 0
         ? found // last node, return it
-        : FindNode(string.Join(".", folders.Except(new[] { head })), found); // find sub nodes
+        : FindNode(string.Join(".", folders), found); // find sub nodes
     }
 
 


### PR DESCRIPTION
If the tag folder path is like "YPLC.YPLC.BLK01.Bth1_Traffic_Cmd", the root folder is "YPLC" has a child folder named "YPLC" also. There will throw some OpcException in UaClient.FindNode method. Its because `folders.Except(new[] { head })` method will Remove all strings named "YPLC".