### PR TITLE
Correct bracket in README.md connect with options example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ or with options...
 var options = new UaClientOptions {
   UserIdentity = new Opc.Ua.UserIdentity("<your-username>", "<your-password>")
 };
-using (var client = new UaClient(new Uri("opc.tcp://host-url")), options)
+using (var client = new UaClient(new Uri("opc.tcp://host-url"), options))
 {
   client.Connect();
   // Use `client` here


### PR DESCRIPTION
In the example there's a bracket in the wrong place resulting in code that would not work.