### PR TITLE
Make UaClientOptions constructor public

### DIFF
--- a/h-opc/Ua/UaClientOptions.cs
+++ b/h-opc/Ua/UaClientOptions.cs
@@ -97,7 +97,7 @@ namespace Hylasoft.Opc.Ua
     /// </summary>
     public OpcUa.UserIdentity UserIdentity { get; set; }
 
-    internal UaClientOptions()
+    public UaClientOptions()
     {
       // Initialize default values:
       ApplicationName = "h-opc-client";

--- a/h-opc/Ua/UaClientOptions.cs
+++ b/h-opc/Ua/UaClientOptions.cs
@@ -97,6 +97,9 @@ namespace Hylasoft.Opc.Ua
     /// </summary>
     public OpcUa.UserIdentity UserIdentity { get; set; }
 
+    /// <summary>
+    /// Creates a client options object
+    /// </summary>
     public UaClientOptions()
     {
       // Initialize default values:


### PR DESCRIPTION
A fix for https://github.com/hylasoft-usa/h-opc/issues/64 where by the example code in the README.md did not work.

Before this commit one needed to something like this to get an instance of `UaClientOptions`:
```
var dummyClient = new UaClient(new Uri("opc.tcp://host-url"));
var options = dummyClient.Options;
options.UserIdentity = new UserIdentity("username", "password");
using (var client = new UaClient(new Uri("opc.tcp://host-url"), options))
    {
        ...
    }
```

Which isn't very nice. This was because the constructor for `UaClientOptions` was internal.