### PR TITLE
Remove reference to unused Microsoft test dll

### DIFF
--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -83,11 +83,7 @@
         <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
+    <Otherwise />
   </Choose>
   <ItemGroup>
     <Compile Include="TestExtendDaClient.cs" />


### PR DESCRIPTION
Test project would not build because of reference to Microsoft Unit testing dll.